### PR TITLE
Fix call_dropped metric

### DIFF
--- a/include/circuit_breaker.hrl
+++ b/include/circuit_breaker.hrl
@@ -36,6 +36,7 @@
 -define(error,                 error).
 -define(timeout,               timeout).
 -define(call_timeout,          call_timeout).
+-define(call_dropped,          call_dropped).
 -define(ok_time_metric,        ok_time_metric).
 
 %%%_* Emacs ============================================================

--- a/src/circuit_breaker.erl
+++ b/src/circuit_breaker.erl
@@ -159,7 +159,7 @@ call(Service, CallFun, CallTimeout, ResetFun, ResetTimeout) ->
 call(Service, CallFun, CallTimeout, ResetFun, ResetTimeout, Thresholds) ->
   case read(Service) of
     R when (R#circuit_breaker.flags > ?CIRCUIT_BREAKER_WARNING) ->
-      event(call_dropped, Service),
+      event(?call_dropped, R),
       {error, {circuit_breaker, R#circuit_breaker.flags}};
     _ -> do_call(Service, CallFun, CallTimeout, ResetFun,
                  ResetTimeout, Thresholds)


### PR DESCRIPTION
This requires yet another dance as @mikpe suggested, merge this commit, remove tag `1.0.4` and tag this change as `1.0.5`. 